### PR TITLE
Fix code quote markdown

### DIFF
--- a/guides/course-setup.md
+++ b/guides/course-setup.md
@@ -147,7 +147,7 @@ the previous section.
    If you have an error that looks like the following:
 
    ```
-  Could not rename config section 'remote.[old name]' to 'remote.[new name]'
+   Could not rename config section 'remote.[old name]' to 'remote.[new name]'
    ```
 
    Or this error:


### PR DESCRIPTION
Just added a missing tab to fix the markdown in the "could not rename config section error" example.